### PR TITLE
Added support for bindswitch command

### DIFF
--- a/syntax/swayconfig.vim
+++ b/syntax/swayconfig.vim
@@ -68,9 +68,9 @@ syn match swayConfigModifier /\w\++\w\+\(\(+\w\+\)\+\)\?/ contained contains=swa
 syn match swayConfigNumber /\s\d\+/ contained
 syn match swayConfigUnit /\sp\(pt\|x\)/ contained
 syn match swayConfigUnitOr /\sor/ contained
-syn keyword swayConfigBindKeyword bindsym bindcode exec gaps border contained
+syn keyword swayConfigBindKeyword bindsym bindcode bindswitch exec gaps border contained
 syn match swayConfigBindArgument /--\w\+\(\(-\w\+\)\+\)\?\s/ contained
-syn match swayConfigBind /^\s*\(bindsym\|bindcode\)\s\+.*$/ contains=swayConfigVariable,swayConfigBindKeyword,swayConfigVariableAndModifier,swayConfigNumber,swayConfigUnit,swayConfigUnitOr,swayConfigBindArgument,swayConfigModifier,swayConfigAction,swayConfigString,swayConfigGapStyleKeyword,swayConfigBorderStyleKeyword
+syn match swayConfigBind /^\s*\(bindsym\|bindcode\|bindswitch\)\s\+.*$/ contains=swayConfigVariable,swayConfigBindKeyword,swayConfigVariableAndModifier,swayConfigNumber,swayConfigUnit,swayConfigUnitOr,swayConfigBindArgument,swayConfigModifier,swayConfigAction,swayConfigString,swayConfigGapStyleKeyword,swayConfigBorderStyleKeyword
 
 " Floating
 syn keyword swayConfigFloatingModifier floating_modifier contained

--- a/test.swayconfig
+++ b/test.swayconfig
@@ -47,6 +47,8 @@ bindsym XF86MonBrightnessUp exec xbacklight -inc 5
 bindsym XF86MonBrightnessDown exec xbacklight -dec 5
 bindsym $mod+u border none
 bindsym $mod+y border pixel $def_border_pix
+bindswitch --reload --locked lid:on output $laptop disable
+bindswitch --reload --locked lid:off output $laptop enable
 
 
 # 6) Floating


### PR DESCRIPTION
Dealing with [clamshell mode](https://github.com/swaywm/sway/wiki#clamshell-mode) requires the use of `bindswitch` command, which I have noticed that it is not supported.