### PR TITLE
add 'always' option for 'focus_follows_mouse'

### DIFF
--- a/syntax/swayconfig.vim
+++ b/syntax/swayconfig.vim
@@ -168,8 +168,8 @@ syn match swayConfigMouseWarping /^\s*mouse_warping\s\+\(output\|none\)\s\?$/ co
 
 " Focus follows mouse
 syn keyword swayConfigFocusFollowsMouseKeyword focus_follows_mouse contained
-syn keyword swayConfigFocusFollowsMouseType yes no contained
-syn match swayConfigFocusFollowsMouse /^\s*focus_follows_mouse\s\+\(yes\|no\)\s\?$/ contains=swayConfigFocusFollowsMouseKeyword,swayConfigFocusFollowsMouseType
+syn keyword swayConfigFocusFollowsMouseType yes no always contained
+syn match swayConfigFocusFollowsMouse /^\s*focus_follows_mouse\s\+\(yes\|no\|always\)\s\?$/ contains=swayConfigFocusFollowsMouseKeyword,swayConfigFocusFollowsMouseType
 
 " Popups during fullscreen mode
 syn keyword swayConfigPopupOnFullscreenKeyword popup_during_fullscreen contained

--- a/test.swayconfig
+++ b/test.swayconfig
@@ -281,6 +281,7 @@ bindsym $mod+u resize grow height 5 px or 5 ppt
 # 30) Focus follow mouse
 focus_follows_mouse no
 focus_follows_mouse yes
+focus_follows_mouse always
 
 # 31) Mouse wrapping
 mouse_warping none


### PR DESCRIPTION
In addition to the `yes` and `no` values for the `focus_follows_mouse`, sway also permits an `always` value.